### PR TITLE
Allow up to 10 open pull requests.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    # Allow up to 10 open pull requests for npm dependencies
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Allow up to 10 open pull requests for npm dependencies.